### PR TITLE
fix tests with new version of bigmemory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,6 @@ matrix:
       warnings_are_errors: false
 r_github_packages:
   - jimhester/covr
+  - kaneplusplus/bigmemory
 after_success:
   - Rscript -e 'covr::codecov()'

--- a/R/class.R
+++ b/R/class.R
@@ -299,7 +299,7 @@ calc_group_sizes = function (delay=TRUE) {
     } else if (!filtered) {
         group_cache[, 3] <<- (group_cache[, 2] - group_cache[, 1]) + 1
         if (any(group_cache[, 1] == 0)) {
-            group_cache[group_cache[, 1] == 0, 3] <<- 0
+            group_cache[which(group_cache[, 1] == 0), 3] <<- 0
         }
     } else {
         N <- length(cls)
@@ -516,7 +516,7 @@ compact = function () {
     if (grouped) {
         .self$sort (decreasing=FALSE, cols=rg_cols, with.group=FALSE)
         nonempty <- (1:group_max) %in% .self$bm[, .self$groupcol]
-        group_cache[!nonempty, 1:3] <<- rep(0, 3)
+        group_cache[which(!nonempty), 1:3] <<- rep(0, 3)
         nonempty <- which (nonempty)
 
         for (g in nonempty) {

--- a/R/internal.R
+++ b/R/internal.R
@@ -268,8 +268,10 @@ sm_desc_subset <- function (.self, first, last) {
 #' @export
 #' @keywords internal
 sm_desc_update <- function (desc, first, last) {
-    desc@description$rowOffset <- desc@description$rowOffset + first - 1
-    desc@description$nrow <- last - first + 1
+    desc@description$rowOffset <- c(
+        (desc@description$rowOffset[1] + first) - 1,
+        (last-first)+1)
+    desc@description$nrow <- (last - first)+1
     return (desc)
 }
 

--- a/R/internal.R
+++ b/R/internal.R
@@ -268,10 +268,8 @@ sm_desc_subset <- function (.self, first, last) {
 #' @export
 #' @keywords internal
 sm_desc_update <- function (desc, first, last) {
-    desc@description$rowOffset <- c(
-        (desc@description$rowOffset[1] + first) - 1,
-        (last-first)+1)
-    desc@description$nrow <- (last - first)+1
+    desc@description$rowOffset <- desc@description$rowOffset + first - 1
+    desc@description$nrow <- last - first + 1
     return (desc)
 }
 


### PR DESCRIPTION
A new version of bigmemory is coming to CRAN and your package needs 2 minor updates to be able to use it.
- `rowOffset` and `colOffset` are not of size 2 anymore because it was useless (as the argument was coding respectively `nrow` and `ncol`).
- subsetting with booleans seems to not work anymore (may be fixed later). So I replaced them by using `which`.

**Edit:** it seems that the feature about `rowOffset` won't be part of the release (it will come in the next). So don't worry about it.